### PR TITLE
Use latest viewsaurus-ringcentral from npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ These are the things you will need before you get started:
 
 ## Installation
 
-Install [RingCentral Themed - viewsaurus](https://github.com/pkvenu/viewsaurus) to the GLOBAL NPM space of your local workstation
+Install RingCentral Themed - viewsaurus to the GLOBAL NPM space of your local workstation
 
 ```
-npm install -g https://github.com/pkvenu/viewsaurus
+npm install -g viewsaurus-ringcentral
 ```
 
 ## Getting Started


### PR DESCRIPTION
https://github.com/pkvenu/viewsaurus is not the right version with RingCentral theme.

https://github.com/ringcentral/viewsaurus for some reason is a private repository.

I feel it is necessary to use a version from NPM